### PR TITLE
Remove debug logging from shift parsing

### DIFF
--- a/ShiftPay/src/models/Shift.ts
+++ b/ShiftPay/src/models/Shift.ts
@@ -75,9 +75,6 @@ export default class Shift {
     let shifts: Shift[] = [];
     let success = true;
 
-    console.log('Parsing multiple shifts:');
-    console.table(data);
-
     try {
       shifts = data
         .map((rawShift: unknown) => {


### PR DESCRIPTION
Eliminated console.log and console.table statements from the Shift model's multiple shift parsing method to clean up debug output.