### PR TITLE
Refactor workInfos to use Map and payRates array

### DIFF
--- a/ShiftPay/src/api.ts
+++ b/ShiftPay/src/api.ts
@@ -98,19 +98,19 @@ export const api = {
     }
   },
 
-  summary: {
-    async fetch(arg?: QueryParams) {
-      return createRequest('summary', { method: 'GET', queryParams: arg });
-    }
-  },
+  // summary: {
+  //   async fetch(arg?: QueryParams) {
+  //     return createRequest('summary', { method: 'GET', queryParams: arg });
+  //   }
+  // },
 
   workInfos: {
     async fetch() {
       return createRequest('workInfos', { method: 'GET' });
     },
 
-    async create(workplace: string, payRate: number) {
-      return createRequest('workInfos', { method: 'POST', body: { workplace, payRate } });
+    async create(workplace: string, payRates: number[]) {
+      return createRequest('workInfos', { method: 'POST', body: { workplace, payRates } });
     },
 
     // No update
@@ -122,19 +122,19 @@ export const api = {
 
       return createRequest('workInfos', { method: 'DELETE', queryParams });
     }
-  },
-
-  shiftTemplates: {
-    async fetch() {
-      return createRequest('shiftTemplates', { method: 'GET' });
-    },
-
-    async create(shift: Shift) {
-      return createRequest('shiftTemplates', { method: 'POST', body: shift.toDTO() });
-    },
-
-    async delete(id: string) {
-      return createRequest(`shiftTemplates/${id}`, { method: 'DELETE' });
-    }
   }
+
+  // shiftTemplates: {
+  //   async fetch() {
+  //     return createRequest('shiftTemplates', { method: 'GET' });
+  //   },
+
+  //   async create(shift: Shift) {
+  //     return createRequest('shiftTemplates', { method: 'POST', body: shift.toDTO() });
+  //   },
+
+  //   async delete(id: string) {
+  //     return createRequest(`shiftTemplates/${id}`, { method: 'DELETE' });
+  //   }
+  // }
 };

--- a/ShiftPay/src/components/ShiftForm.vue
+++ b/ShiftPay/src/components/ShiftForm.vue
@@ -295,11 +295,12 @@ export default {
     </InputLabel>
 
     <InputLabel label-text="Workplace" for-id="workplace">
-      <ComboBox :value="formData?.workplace || ''" @update:value="newValue => formData.workplace = newValue"
-        :list="Object.keys(workInfosStore.workInfos)" @delete-item="workInfo => workInfosStore.delete(workInfo)"
+      <ComboBox :value="formData?.workplace || ''"
+        @update:value="newValue => { formData.workplace = newValue; formData.payRate = undefined; }"
+        :list="Array.from(workInfosStore.workInfos.keys())" @delete-item="workInfo => workInfosStore.delete(workInfo)"
         deletable>
-        <input type="text" id="workplace" name="workplace" placeholder="e.g. Company Name" v-model="formData.workplace"
-          required />
+        <input type="search" id="workplace" name="workplace" placeholder="e.g. Company Name"
+          v-model="formData.workplace" required />
       </ComboBox>
     </InputLabel>
 

--- a/ShiftPay/src/stores/workInfosStore.ts
+++ b/ShiftPay/src/stores/workInfosStore.ts
@@ -24,19 +24,10 @@ export const useWorkInfosStore = defineStore('workInfos', {
 
         // Parse & Validate
         this.workInfos = new Map<string, WorkInfo>(
-          Object.entries(
-            JSON.parse(rawData, function (_, value) {
-              if (typeof value === 'object' && value !== null) {
-                // Convert payRates array to Set
-                if (Array.isArray(value.payRates)) {
-                  value.payRates = new Set(value.payRates);
-                }
-              }
-
-              return value;
-            })
-          )
+          JSON.parse(rawData).map((workInfo: any) => [workInfo.workplace, { payRates: new Set(workInfo.payRates) }])
         );
+
+        console.log(this.workInfos);
 
         localStorage.removeItem('prevWorkInfos'); // Remove old key
       });
@@ -136,13 +127,16 @@ export const useWorkInfosStore = defineStore('workInfos', {
       this.$subscribe(
         function (_mutation, state) {
           localStorage.setItem(
-            'prevWorkInfos',
-            JSON.stringify(state.workInfos, function (_, value) {
-              if (value instanceof Set) {
-                return Array.from(value);
-              }
-              return value;
-            })
+            'workInfos',
+            JSON.stringify(
+              Array.from(state.workInfos, (workInfo) => {
+                console.log(workInfo);
+                return {
+                  workplace: workInfo[0],
+                  payRates: Array.from(workInfo[1].payRates)
+                };
+              })
+            )
           );
         },
         { detached: true }


### PR DESCRIPTION
Updated workInfos data structure to use a Map with workplace as key and payRates as an array, replacing previous object-based approach. Adjusted API, store, and ShiftForm component to support multiple pay rates per workplace and improved localStorage serialization/deserialization logic.